### PR TITLE
Version added to Cloudflare provider.

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -8,6 +8,7 @@ provider "digitalocean" {
 }
 
 provider "cloudflare" {
+  version = "~> 1.0"
   email = "${var.cloudflare_email}"
   token = "${var.cloudflare_token}"
 }


### PR DESCRIPTION
TF Cloudflare provider is version 2.0.0 currently. It has changes in its properties (e.g. api_key instead token etc.). Setting to version 1.x is necessary, until the version 2.x changes are fully incorporated. 